### PR TITLE
Ignore Additional Streams (Audio)

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -136,8 +136,11 @@ func rtspConsumer() {
 		codecs, err := session.Streams()
 		if err != nil {
 			panic(err)
-		} else if len(codecs) != 1 || codecs[0].Type() != av.H264 {
+		} else if codecs[0].Type() != av.H264 {
 			panic("RTSP feed must be a single H264 codec")
+		}
+		if len(codecs) != 1 {
+			fmt.Println("Ignoring all but the first stream.")
 		}
 
 		var previousTime time.Duration

--- a/server/main.go
+++ b/server/main.go
@@ -136,11 +136,15 @@ func rtspConsumer() {
 		codecs, err := session.Streams()
 		if err != nil {
 			panic(err)
-		} else if codecs[0].Type() != av.H264 {
-			panic("RTSP feed must be a single H264 codec")
+		}
+		for i, t := range codecs {
+			log.Println("Stream", i, "is of type", t.Type().String())
+		}
+		if codecs[0].Type() != av.H264 {
+			panic("RTSP feed must begin with a H264 codec")
 		}
 		if len(codecs) != 1 {
-			fmt.Println("Ignoring all but the first stream.")
+			log.Printf("Ignoring all but the first stream. %s\n", codecs[0].Type().String())
 		}
 
 		var previousTime time.Duration

--- a/server/main.go
+++ b/server/main.go
@@ -144,7 +144,7 @@ func rtspConsumer() {
 			panic("RTSP feed must begin with a H264 codec")
 		}
 		if len(codecs) != 1 {
-			log.Printf("Ignoring all but the first stream. %s\n", codecs[0].Type().String())
+			log.Println("Ignoring all but the first stream.")
 		}
 
 		var previousTime time.Duration


### PR DESCRIPTION
#### Description
Allows use of RTSP streams that include additional audio stream (ignores audio instead of panicking). Tested on Axis M1065-L.

Note to the maintainers: this is some of my first golang code so please review carefully.